### PR TITLE
Change to legacy compile type

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,12 +8,17 @@ repositories {
 }
 
 dependencies {
-    testImplementation(kotlin("test-js"))
     implementation(project(":htmlcanvas"))
     implementation(project(":keycommand"))
+    implementation(project(":lifecycle"))
+    implementation(project(":shape"))
+    implementation(project(":monoboard"))
+    implementation(project(":monobitmap"))
     implementation(project(":graphicsgeo"))
     implementation(project(":livedata"))
     implementation(project(":statemanager"))
+
+    testImplementation(kotlin("test-js"))
 }
 
 kotlin {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
 }
 
 kotlin {
-    js(IR) {
+    js(LEGACY) {
         browser {
             testTask {
                 useKarma {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
 }
 
 kotlin {
-    js(IR) {
+    js(LEGACY) {
         browser {
             binaries.executable()
             webpackTask {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     implementation(kotlin("stdlib-js"))
     implementation("org.jetbrains.kotlinx:kotlinx-html-js:0.7.2")
     implementation(project(":app"))
+    implementation(project(":lifecycle"))
     implementation(project(":livedata"))
 
     testImplementation(kotlin("test-js"))

--- a/libs/commons/build.gradle.kts
+++ b/libs/commons/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
 }
 
 kotlin {
-    js(IR) {
+    js(LEGACY) {
         browser {
             testTask {
                 useKarma {

--- a/libs/graphicsgeo/build.gradle.kts
+++ b/libs/graphicsgeo/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
 }
 
 kotlin {
-    js(IR) {
+    js(LEGACY) {
         browser {
             testTask {
                 useKarma {

--- a/libs/htmlcanvas/build.gradle.kts
+++ b/libs/htmlcanvas/build.gradle.kts
@@ -9,7 +9,10 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-html:0.7.2")
+    implementation(project(":commons"))
+    implementation(project(":graphicsgeo"))
     implementation(project(":monoboard"))
+    implementation(project(":lifecycle"))
     implementation(project(":livedata"))
     implementation(project(":shape-interaction-bound"))
 

--- a/libs/htmlcanvas/build.gradle.kts
+++ b/libs/htmlcanvas/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
 }
 
 kotlin {
-    js(IR) {
+    js(LEGACY) {
         browser {
             testTask {
                 useKarma {

--- a/libs/htmlmodal/build.gradle.kts
+++ b/libs/htmlmodal/build.gradle.kts
@@ -9,6 +9,8 @@ repositories {
 
 dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-html:0.7.2")
+    implementation(project(":commons"))
+    implementation(project(":lifecycle"))
     implementation(project(":livedata"))
 
     testImplementation(kotlin("test-js"))

--- a/libs/htmlmodal/build.gradle.kts
+++ b/libs/htmlmodal/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
 }
 
 kotlin {
-    js(IR) {
+    js(LEGACY) {
         browser {
             testTask {
                 useKarma {

--- a/libs/keycommand/build.gradle.kts
+++ b/libs/keycommand/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
 }
 
 kotlin {
-    js(IR) {
+    js(LEGACY) {
         browser {
             testTask {
                 useKarma {

--- a/libs/lifecycle/build.gradle.kts
+++ b/libs/lifecycle/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
 }
 
 kotlin {
-    js(IR) {
+    js(LEGACY) {
         browser {
             binaries.executable()
 

--- a/libs/livedata/build.gradle.kts
+++ b/libs/livedata/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
 }
 
 kotlin {
-    js(IR) {
+    js(LEGACY) {
         browser {
             binaries.executable()
 

--- a/libs/monobitmap/build.gradle.kts
+++ b/libs/monobitmap/build.gradle.kts
@@ -10,8 +10,10 @@ repositories {
 
 dependencies {
     implementation(project(":commons"))
+    implementation(project(":graphicsgeo"))
     implementation(project(":shape"))
     implementation(kotlin("stdlib-js"))
+    
     testImplementation(kotlin("test-js"))
 }
 

--- a/libs/monobitmap/build.gradle.kts
+++ b/libs/monobitmap/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
 }
 
 kotlin {
-    js(IR) {
+    js(LEGACY) {
         browser {
             testTask {
                 useKarma {

--- a/libs/monoboard/build.gradle.kts
+++ b/libs/monoboard/build.gradle.kts
@@ -9,8 +9,11 @@ repositories {
 }
 
 dependencies {
+    implementation(project(":commons"))
+    implementation(project(":graphicsgeo"))
     implementation(project(":monobitmap"))
     implementation(kotlin("stdlib-js"))
+    
     testImplementation(kotlin("test-js"))
 }
 

--- a/libs/monoboard/build.gradle.kts
+++ b/libs/monoboard/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
 }
 
 kotlin {
-    js(IR) {
+    js(LEGACY) {
         browser {
             testTask {
                 useKarma {

--- a/libs/shape-interaction-bound/build.gradle.kts
+++ b/libs/shape-interaction-bound/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
 }
 
 kotlin {
-    js(IR) {
+    js(LEGACY) {
         browser {
             testTask {
                 useKarma {

--- a/libs/shape/build.gradle.kts
+++ b/libs/shape/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
 }
 
 kotlin {
-    js(IR) {
+    js(LEGACY) {
         browser {
             testTask {
                 useKarma {

--- a/libs/shapesearcher/build.gradle.kts
+++ b/libs/shapesearcher/build.gradle.kts
@@ -8,6 +8,8 @@ repositories {
 }
 
 dependencies {
+    implementation(project(":commons"))
+    implementation(project(":graphicsgeo"))
     implementation(project(":shape"))
     implementation(project(":monobitmap"))
 

--- a/libs/shapesearcher/build.gradle.kts
+++ b/libs/shapesearcher/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
 }
 
 kotlin {
-    js(IR) {
+    js(LEGACY) {
         browser {
             testTask {
                 useKarma {

--- a/libs/statemanager/build.gradle.kts
+++ b/libs/statemanager/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
 }
 
 kotlin {
-    js(IR) {
+    js(LEGACY) {
         browser {
             testTask {
                 useKarma {

--- a/libs/statemanager/build.gradle.kts
+++ b/libs/statemanager/build.gradle.kts
@@ -9,14 +9,20 @@ repositories {
 
 dependencies {
     implementation(kotlin("stdlib-js"))
+    implementation("org.jetbrains.kotlinx:kotlinx-html:0.7.2")
+    implementation(project(":commons"))
+    implementation(project(":graphicsgeo"))
+    implementation(project(":lifecycle"))
     implementation(project(":livedata"))
     implementation(project(":shape"))
     implementation(project(":shapesearcher"))
     implementation(project(":monoboard"))
     implementation(project(":shape-interaction-bound"))
     implementation(project(":htmlcanvas"))
+    implementation(project(":monobitmap"))
     implementation(project(":htmlmodal"))
     implementation(project(":keycommand"))
+    
     testImplementation(kotlin("test-js"))
 }
 


### PR DESCRIPTION
IR compile type is not ready yet and neither this project.
LEGACY support running specific test case as well as able to print Kotlin file stack trace.
When IR compile type is ready, I will reapply then