### PR TITLE
Improve drawing for cross points

### DIFF
--- a/libs/monoboard/src/main/kotlin/mono/graphics/board/CrossingResources.kt
+++ b/libs/monoboard/src/main/kotlin/mono/graphics/board/CrossingResources.kt
@@ -1,0 +1,8 @@
+package mono.graphics.board
+
+/**
+ * An objects that defines resources for crossing.
+ */
+internal object CrossingResources {
+    val CONNECTABLE_CHARS = "-─|│┌└┐┘┬┴├┤┼".toSet()
+}

--- a/libs/monoboard/src/main/kotlin/mono/graphics/board/CrossingResources.kt
+++ b/libs/monoboard/src/main/kotlin/mono/graphics/board/CrossingResources.kt
@@ -5,4 +5,262 @@ package mono.graphics.board
  */
 internal object CrossingResources {
     val CONNECTABLE_CHARS = "-─|│┌└┐┘┬┴├┤┼".toSet()
+
+    val LEFT_IN_CHARS = "-─┌└┬┴├┼".toSet()
+    val RIGHT_IN_CHARS = "-─┐┘┴┤┼".toSet()
+    val TOP_IN_CHARS = "|│┌┐┬├┤┼".toSet()
+    val BOTTOM_IN_CHARS = "|│└┘┴├┤┼".toSet()
+
+    val CONNECTOR_CHAR_MAP = mapOf(
+        "─│" to mapOf(
+            inDirectionMark(hasRight = true, hasVertical = true) to '├',
+            inDirectionMark(hasLeft = true, hasVertical = true) to '┤',
+            inDirectionMark(hasHorizontal = true, hasVertical = true) to '┼',
+            inDirectionMark(hasHorizontal = true, hasTop = true) to '┴',
+            inDirectionMark(hasHorizontal = true, hasBottom = true) to '┬'
+        ),
+
+        "─┌" to mapOf(
+            inDirectionMark(hasRight = true, hasBottom = true) to '┌',
+            inDirectionMark(hasHorizontal = true, hasBottom = true) to '┬'
+        ),
+
+        "─└" to mapOf(
+            inDirectionMark(hasRight = true, hasTop = true) to '└',
+            inDirectionMark(hasHorizontal = true, hasTop = true) to '┴'
+        ),
+
+        "─┐" to mapOf(
+            inDirectionMark(hasRight = true, hasBottom = true) to '┐',
+            inDirectionMark(hasHorizontal = true, hasBottom = true) to '┬'
+        ),
+
+        "─┘" to mapOf(
+            inDirectionMark(hasRight = true, hasTop = true) to '┘',
+            inDirectionMark(hasHorizontal = true, hasTop = true) to '┴'
+        ),
+
+        "─├" to mapOf(
+            inDirectionMark(hasHorizontal = true, hasVertical = true) to '┼',
+            inDirectionMark(hasVertical = true, hasRight = true) to '├'
+        ),
+
+        "─┤" to mapOf(
+            inDirectionMark(hasHorizontal = true, hasVertical = true) to '┼'
+        ),
+
+        "─┴" to mapOf(
+            inDirectionMark(hasHorizontal = true, hasTop = true) to '┴'
+        ),
+
+        "─┬" to mapOf(
+            inDirectionMark(hasHorizontal = true, hasBottom = true) to '┬'
+        ),
+
+        "─┼" to mapOf(
+            inDirectionMark(hasHorizontal = true, hasVertical = true) to '┼'
+        ),
+
+        "│┌" to mapOf(
+            inDirectionMark(hasBottom = true, hasRight = true) to '┌',
+            inDirectionMark(hasVertical = true, hasRight = true) to '├'
+        ),
+
+        "│└" to mapOf(
+            inDirectionMark(hasTop = true, hasRight = true) to '└',
+            inDirectionMark(hasVertical = true, hasRight = true) to '├'
+        ),
+
+        "│┐" to mapOf(
+            inDirectionMark(hasBottom = true, hasLeft = true) to '┐',
+            inDirectionMark(hasVertical = true, hasLeft = true) to '┤'
+        ),
+
+        "│┘" to mapOf(
+            inDirectionMark(hasTop = true, hasLeft = true) to '┘',
+            inDirectionMark(hasVertical = true, hasLeft = true) to '┤'
+        ),
+
+        "│├" to mapOf(
+            inDirectionMark(hasVertical = true, hasRight = true) to '├'
+        ),
+
+        "│┤" to mapOf(
+            inDirectionMark(hasVertical = true, hasLeft = true) to '┤'
+        ),
+
+        "│┴" to mapOf(
+            inDirectionMark(hasHorizontal = true, hasVertical = true) to '┼'
+        ),
+
+        "│┬" to mapOf(
+            inDirectionMark(hasHorizontal = true, hasVertical = true) to '┼'
+        ),
+
+        "│┼" to mapOf(
+            inDirectionMark(hasHorizontal = true, hasVertical = true) to '┼'
+        ),
+
+        "┌└" to mapOf(
+            inDirectionMark(hasVertical = true, hasRight = true) to '├'
+        ),
+
+        "┌┘" to mapOf(
+            inDirectionMark(hasHorizontal = true, hasVertical = true) to '┼'
+        ),
+
+        "┌┐" to mapOf(
+            inDirectionMark(hasHorizontal = true, hasBottom = true) to '┬'
+        ),
+
+        "┌├" to mapOf(
+            inDirectionMark(hasVertical = true, hasRight = true) to '├'
+        ),
+
+        "┌┤" to mapOf(
+            inDirectionMark(hasHorizontal = true, hasVertical = true) to '┼'
+        ),
+
+        "┌┴" to mapOf(
+            inDirectionMark(hasHorizontal = true, hasVertical = true) to '┼'
+        ),
+
+        "┌┬" to mapOf(
+            inDirectionMark(hasHorizontal = true, hasBottom = true) to '┬'
+        ),
+
+        "┌┼" to mapOf(
+            inDirectionMark(hasHorizontal = true, hasVertical = true) to '┼'
+        ),
+
+        "└┐" to mapOf(
+            inDirectionMark(hasHorizontal = true, hasVertical = true) to '┼'
+        ),
+
+        "└┘" to mapOf(
+            inDirectionMark(hasHorizontal = true, hasTop = true) to '┴'
+        ),
+
+        "└├" to mapOf(
+            inDirectionMark(hasVertical = true, hasRight = true) to '├'
+        ),
+
+        "└┤" to mapOf(
+            inDirectionMark(hasHorizontal = true, hasVertical = true) to '┼'
+        ),
+
+        "└┴" to mapOf(
+            inDirectionMark(hasHorizontal = true, hasTop = true) to '┴'
+        ),
+
+        "└┬" to mapOf(
+            inDirectionMark(hasHorizontal = true, hasVertical = true) to '┼'
+        ),
+
+        "└┼" to mapOf(
+            inDirectionMark(hasHorizontal = true, hasVertical = true) to '┼'
+        ),
+
+        "┘┐" to mapOf(
+            inDirectionMark(hasVertical = true, hasLeft = true) to '┤'
+        ),
+
+        "┘├" to mapOf(
+            inDirectionMark(hasHorizontal = true, hasVertical = true) to '┼'
+        ),
+
+        "┘┤" to mapOf(
+            inDirectionMark(hasVertical = true, hasLeft = true) to '┤'
+        ),
+
+        "┘┴" to mapOf(
+            inDirectionMark(hasHorizontal = true, hasTop = true) to '┴'
+        ),
+
+        "┘┬" to mapOf(
+            inDirectionMark(hasHorizontal = true, hasVertical = true) to '┼'
+        ),
+
+        "┘┼" to mapOf(
+            inDirectionMark(hasHorizontal = true, hasVertical = true) to '┼'
+        ),
+
+        "┐├" to mapOf(
+            inDirectionMark(hasHorizontal = true, hasVertical = true) to '┼'
+        ),
+
+        "┐┤" to mapOf(
+            inDirectionMark(hasVertical = true, hasLeft = true) to '┤'
+        ),
+
+        "┐┴" to mapOf(
+            inDirectionMark(hasHorizontal = true, hasVertical = true) to '┼'
+        ),
+
+        "┐┬" to mapOf(
+            inDirectionMark(hasHorizontal = true, hasBottom = true) to '┬'
+        ),
+
+        "┐┼" to mapOf(
+            inDirectionMark(hasHorizontal = true, hasVertical = true) to '┼'
+        ),
+
+        "├┤" to mapOf(
+            inDirectionMark(hasHorizontal = true, hasVertical = true) to '┼'
+        ),
+
+        "├┴" to mapOf(
+            inDirectionMark(hasHorizontal = true, hasVertical = true) to '┼'
+        ),
+
+        "├┬" to mapOf(
+            inDirectionMark(hasHorizontal = true, hasVertical = true) to '┼'
+        ),
+
+        "├┼" to mapOf(
+            inDirectionMark(hasHorizontal = true, hasVertical = true) to '┼'
+        ),
+
+        "┤┴" to mapOf(
+            inDirectionMark(hasHorizontal = true, hasVertical = true) to '┼'
+        ),
+
+        "┤┬" to mapOf(
+            inDirectionMark(hasHorizontal = true, hasVertical = true) to '┼'
+        ),
+
+        "┤┼" to mapOf(
+            inDirectionMark(hasHorizontal = true, hasVertical = true) to '┼'
+        ),
+
+        "┴┬" to mapOf(
+            inDirectionMark(hasHorizontal = true, hasVertical = true) to '┼'
+        ),
+
+        "┴┼" to mapOf(
+            inDirectionMark(hasHorizontal = true, hasVertical = true) to '┼'
+        ),
+
+        "┬┼" to mapOf(
+            inDirectionMark(hasHorizontal = true, hasVertical = true) to '┼'
+        )
+    )
+
+    /**
+     * An utility method for creating a mark vector for in-directions.
+     */
+    fun inDirectionMark(
+        hasLeft: Boolean = false,
+        hasRight: Boolean = false,
+        hasTop: Boolean = false,
+        hasBottom: Boolean = false,
+        hasHorizontal: Boolean = false,
+        hasVertical: Boolean = false
+    ): Int {
+        val leftMark = if (hasLeft || hasHorizontal) 0b1 else 0
+        val rightMark = if (hasRight || hasHorizontal) 0b10 else 0
+        val topMark = if (hasTop || hasVertical) 0b100 else 0
+        val bottomMark = if (hasBottom || hasVertical) 0b1000 else 0
+        return leftMark or topMark or rightMark or bottomMark
+    }
 }

--- a/libs/monoboard/src/main/kotlin/mono/graphics/board/MonoBoard.kt
+++ b/libs/monoboard/src/main/kotlin/mono/graphics/board/MonoBoard.kt
@@ -158,6 +158,29 @@ class MonoBoard(private val unitSize: Size = STANDARD_UNIT_SIZE) {
                 .getOrPut(boardColIndex) { BoardAddress(boardRowIndex, boardColIndex) }
     }
 
+    /**
+     * A data class that stores information of a cross point when drawing a bitmap with
+     * [PainterBoard].
+     * CrossPoint will then be drawn to the board after non-crossing pixels are drawn.
+     *
+     * @param [boardRow] and [boardColumn] are the location of point on the board.
+     * @param [char] is the character at the crossing point
+     * @param [leftChar], [rightChar], [topChar], and [bottomChar] are 4 characters around the
+     * crossing point
+     */
+    internal data class CrossPoint(
+        val boardRow: Int,
+        val boardColumn: Int,
+        val char: Char,
+        val leftChar: Char,
+        val rightChar: Char,
+        val topChar: Char,
+        val bottomChar: Char,
+    ) {
+        val left: Int = boardColumn
+        val top: Int = boardRow
+    }
+
     companion object {
         val STANDARD_UNIT_SIZE = Size(16, 16)
     }

--- a/libs/monoboard/src/main/kotlin/mono/graphics/board/MonoBoard.kt
+++ b/libs/monoboard/src/main/kotlin/mono/graphics/board/MonoBoard.kt
@@ -26,13 +26,6 @@ class MonoBoard(private val unitSize: Size = STANDARD_UNIT_SIZE) {
         }
     }
 
-    fun fill(rect: Rect, char: Char, highlight: Highlight) {
-        val affectedBoards = getOrCreateOverlappedBoards(rect, isCreateRequired = true)
-        for (board in affectedBoards) {
-            board.fill(rect, char, highlight)
-        }
-    }
-
     fun fill(position: Point, bitmap: MonoBitmap, highlight: Highlight) {
         val rect = Rect(position, bitmap.size)
         val affectedBoards = getOrCreateOverlappedBoards(rect, isCreateRequired = true)
@@ -42,10 +35,20 @@ class MonoBoard(private val unitSize: Size = STANDARD_UNIT_SIZE) {
         }
     }
 
-    fun set(position: Point, char: Char, highlight: Highlight) {
+    // This method is for testing only
+    internal fun fill(rect: Rect, char: Char, highlight: Highlight) {
+        val affectedBoards = getOrCreateOverlappedBoards(rect, isCreateRequired = true)
+        for (board in affectedBoards) {
+            board.fill(rect, char, highlight)
+        }
+    }
+
+    // This method is for testing only
+    internal fun set(position: Point, char: Char, highlight: Highlight) {
         set(position.left, position.top, char, highlight)
     }
 
+    // This method is for testing only
     fun set(left: Int, top: Int, char: Char, highlight: Highlight) {
         getOrCreateBoard(left, top, isCreateRequired = true)
             ?.set(left, top, char, highlight)

--- a/libs/monoboard/src/main/kotlin/mono/graphics/board/PainterBoard.kt
+++ b/libs/monoboard/src/main/kotlin/mono/graphics/board/PainterBoard.kt
@@ -2,6 +2,7 @@ package mono.graphics.board
 
 import mono.common.Characters.TRANSPARENT_CHAR
 import mono.graphics.bitmap.MonoBitmap
+import mono.graphics.board.MonoBoard.CrossPoint
 import mono.graphics.geo.Point
 import mono.graphics.geo.Rect
 import mono.graphics.geo.Size
@@ -57,30 +58,66 @@ internal class PainterBoard(internal val bound: Rect) {
     }
 
     /**
-     * Fills with a bitmap and the highlight state of that bitmap from [position].
+     * Fills with a bitmap and the highlight state of that bitmap from [position] excepts crossing
+     * points. Connection point are the point whose the char is one of connection characters defined
+     * in [CrossingResources.CONNECTABLE_CHARS] and there is a character drawn at the position.
+     * A list of [CrossPoint] will be returned to let [MonoBoard] able to adjust and draw the
+     * adjusted character of the connection points.
+     *
+     * The main reason why it is required to let [MonoBoard] draws the connection points is the
+     * painter board cannot see the pixel outside its bound which is required to identify the final
+     * connection character.
+     *
      * If a pixel in input [bitmap] is transparent, the value in the current board at that
      * position won't be overwritten.
      */
-    fun fill(position: Point, bitmap: MonoBitmap, highlight: Highlight) {
+    fun fill(position: Point, bitmap: MonoBitmap, highlight: Highlight): List<CrossPoint> {
         if (bitmap.isEmpty()) {
-            return
+            return emptyList()
         }
         val inMatrix = bitmap.matrix
 
         val inMatrixBound = Rect(position, bitmap.size)
 
-        val overlap = bound.getOverlappedRect(inMatrixBound) ?: return
+        val overlap = bound.getOverlappedRect(inMatrixBound) ?: return emptyList()
         val (startCol, startRow) = overlap.position - bound.position
         val (inStartCol, inStartRow) = overlap.position - position
 
+        val crossingPoints = mutableListOf<CrossPoint>()
+
         for (r in 0 until overlap.height) {
-            val src = inMatrix[inStartRow + r]
-            val dest = matrix[startRow + r]
+            val bitmapRow = inStartRow + r
+            val painterRow = startRow + r
+            val src = inMatrix[bitmapRow]
+            val dest = matrix[painterRow]
 
             src.forEachIndex(inStartCol, inStartCol + overlap.width) { index, char ->
-                dest[startCol + index].set(char, highlight)
+                val bitmapColumn = inStartCol + index
+                val painterColumn = startCol + index
+                val pixel = dest[painterColumn]
+
+                if (pixel.isTransparent ||
+                    pixel.char == char ||
+                    char !in CrossingResources.CONNECTABLE_CHARS
+                ) {
+                    pixel.set(char, highlight)
+                } else {
+                    crossingPoints.add(
+                        CrossPoint(
+                            boardRow = painterRow + bound.position.row,
+                            boardColumn = painterColumn + bound.position.column,
+                            char,
+                            leftChar = bitmap.get(bitmapRow, bitmapColumn - 1),
+                            rightChar = bitmap.get(bitmapRow, bitmapColumn + 1),
+                            topChar = bitmap.get(bitmapRow - 1, bitmapColumn),
+                            bottomChar = bitmap.get(bitmapRow + 1, bitmapColumn),
+                        )
+                    )
+                }
             }
         }
+
+        return crossingPoints
     }
 
     /**

--- a/libs/monoboard/src/main/kotlin/mono/graphics/board/PainterBoard.kt
+++ b/libs/monoboard/src/main/kotlin/mono/graphics/board/PainterBoard.kt
@@ -27,21 +27,6 @@ internal class PainterBoard(internal val bound: Rect) {
     }
 
     /**
-     * Force values overlap with [rect] to be [char] regardless they are [TRANSPARENT_CHAR]
-     */
-    fun fill(rect: Rect, char: Char, highlight: Highlight) {
-        val overlap = bound.getOverlappedRect(rect) ?: return
-        val (startCol, startRow) = overlap.position - bound.position
-
-        for (r in 0 until overlap.height) {
-            val row = matrix[r + startRow]
-            for (c in 0 until overlap.width) {
-                row[c + startCol].set(char, highlight)
-            }
-        }
-    }
-
-    /**
      * Fills with another [PainterBoard].
      * If a pixel in input [PainterBoard] is transparent, the value in the current board at that
      * position won't be overwritten.
@@ -99,11 +84,31 @@ internal class PainterBoard(internal val bound: Rect) {
     }
 
     /**
-     * Force value at [position] to be [char] with [highlight]
+     * Force values overlap with [rect] to be [char] regardless they are [TRANSPARENT_CHAR].
+     *
+     * Note: This method is for testing only
+     */
+    fun fill(rect: Rect, char: Char, highlight: Highlight) {
+        val overlap = bound.getOverlappedRect(rect) ?: return
+        val (startCol, startRow) = overlap.position - bound.position
+
+        for (r in 0 until overlap.height) {
+            val row = matrix[r + startRow]
+            for (c in 0 until overlap.width) {
+                row[c + startCol].set(char, highlight)
+            }
+        }
+    }
+
+    /**
+     * Force value at [position] to be [char] with [highlight].
+     *
+     * Note: This method is for testing only
      */
     fun set(position: Point, char: Char, highlight: Highlight) =
         set(position.left, position.top, char, highlight)
 
+    // This method is for testing only
     fun set(left: Int, top: Int, char: Char, highlight: Highlight) {
         val columnIndex = left - bound.left
         val rowIndex = top - bound.top

--- a/libs/shape/src/main/kotlin/mono/shape/shape/Line.kt
+++ b/libs/shape/src/main/kotlin/mono/shape/shape/Line.kt
@@ -86,9 +86,9 @@ class Line(
     var edges: List<Edge> = LineHelper.createEdges(jointPoints)
         private set
 
-    var anchorCharStart: AnchorChar = AnchorChar('─', '─', '|', '|')
+    var anchorCharStart: AnchorChar = AnchorChar('─', '─', '│', '│')
         private set
-    var anchorCharEnd: AnchorChar = AnchorChar('─', '─', '|', '|')
+    var anchorCharEnd: AnchorChar = AnchorChar('─', '─', '│', '│')
         private set
 
     /**


### PR DESCRIPTION
Make the mono board able to use connection characters at the crossing points
```
┌─────────┬─────┬─────────┐
│         │     │         │
│         │     │         │
│         │     │         │
│         │     │         │
│         │     │         │
├─────────┴─────┴─┬───────┘
│                 └─────┐  
│                       │  
│                       │  
└───────────────────────┘  
```