### PR TITLE
Small fix for crossing resources and export modal

### DIFF
--- a/libs/export-shapes-modal/src/main/kotlin/mono/export/ExportShapesModal.kt
+++ b/libs/export-shapes-modal/src/main/kotlin/mono/export/ExportShapesModal.kt
@@ -112,7 +112,9 @@ class ExportShapesModal(
     private fun TagConsumer<HTMLElement>.Body(content: String) {
         div("modal-body") {
             pre {
-                style = "line-height: 15px; font-size: 12px;height: 100%"
+                attributes["contenteditable"] = "true"
+                style =
+                    "line-height: 15px; font-size: 12px; height: 100%; outline: none; min-height: 160px"
                 +content
             }
         }

--- a/libs/export-shapes-modal/src/main/kotlin/mono/export/ExportShapesModal.kt
+++ b/libs/export-shapes-modal/src/main/kotlin/mono/export/ExportShapesModal.kt
@@ -113,8 +113,8 @@ class ExportShapesModal(
         div("modal-body") {
             pre {
                 attributes["contenteditable"] = "true"
-                style =
-                    "line-height: 15px; font-size: 12px; height: 100%; outline: none; min-height: 160px"
+                style = "line-height: 15px; font-size: 12px; height: 100%; outline: none; " +
+                    "min-height: 160px"
                 +content
             }
         }

--- a/libs/monoboard/src/main/kotlin/mono/graphics/board/CrossingResources.kt
+++ b/libs/monoboard/src/main/kotlin/mono/graphics/board/CrossingResources.kt
@@ -31,12 +31,12 @@ internal object CrossingResources {
         ),
 
         "─┐" to mapOf(
-            inDirectionMark(hasRight = true, hasBottom = true) to '┐',
+            inDirectionMark(hasLeft = true, hasBottom = true) to '┐',
             inDirectionMark(hasHorizontal = true, hasBottom = true) to '┬'
         ),
 
         "─┘" to mapOf(
-            inDirectionMark(hasRight = true, hasTop = true) to '┘',
+            inDirectionMark(hasLeft = true, hasTop = true) to '┘',
             inDirectionMark(hasHorizontal = true, hasTop = true) to '┴'
         ),
 


### PR DESCRIPTION
- Fix bug at the precondition of crossing resource
```
     ┌────────┐
     │        │
     │        │
     │        │
─────┴─────────
```
- Make export modal content text editable