### PR TITLE
Smoother scroll and reduce the number of redraw requests when drawing info is updated

### DIFF
--- a/libs/htmlcanvas/src/main/kotlin/mono/html/canvas/CanvasViewController.kt
+++ b/libs/htmlcanvas/src/main/kotlin/mono/html/canvas/CanvasViewController.kt
@@ -59,6 +59,7 @@ class CanvasViewController(
         mousePointerLiveData = mouseEventController.mousePointerLiveData
         mouseEventController.drawingOffsetPointPxLiveData.observe(
             lifecycleOwner,
+            throttleDurationMillis = 5, // Reduce number of redraw request due to drawingInfo update
             listener = drawingInfoController::setOffset
         )
 

--- a/libs/htmlcanvas/src/main/kotlin/mono/html/canvas/mouse/MouseEventObserver.kt
+++ b/libs/htmlcanvas/src/main/kotlin/mono/html/canvas/mouse/MouseEventObserver.kt
@@ -101,11 +101,12 @@ internal class MouseEventObserver(
         event.preventDefault()
         event.stopPropagation()
 
-        val cellWidthPx = drawingInfo.cellSizePx.width.toFloat()
-        val cellHeightPx = drawingInfo.cellSizePx.height.toFloat()
+        val scrollHorizontalThresholdPx = SCROLL_THRESHOLD_PIXEL
+        val scrollVerticalThresholdPx = SCROLL_THRESHOLD_PIXEL
 
-        val wheelDeltaLeft = event.deltaX.toFloat() / cellWidthPx * SCROLL_SPEED_RATIO
-        val wheelDeltaTop = event.deltaY.toFloat() / cellHeightPx * SCROLL_SPEED_RATIO
+        val wheelDeltaLeft =
+            event.deltaX.toFloat() * SCROLL_SPEED_RATIO / scrollHorizontalThresholdPx
+        val wheelDeltaTop = event.deltaY.toFloat() * SCROLL_SPEED_RATIO / scrollVerticalThresholdPx
         val accumulateWheelDeltaLeft = mouseWheelDeltaX + wheelDeltaLeft
         val accumulateWheelDeltaTop = mouseWheelDeltaY + wheelDeltaTop
 
@@ -113,8 +114,10 @@ internal class MouseEventObserver(
         val usableDeltaTop = accumulateWheelDeltaTop.toInt()
 
         if (usableDeltaLeft != 0 || usableDeltaTop != 0) {
-            val offsetLeft = drawingInfo.offsetPx.left - usableDeltaLeft * cellWidthPx.toInt()
-            val offsetTop = drawingInfo.offsetPx.top - usableDeltaTop * cellHeightPx.toInt()
+            val offsetLeft =
+                drawingInfo.offsetPx.left - usableDeltaLeft * scrollHorizontalThresholdPx.toInt()
+            val offsetTop =
+                drawingInfo.offsetPx.top - usableDeltaTop * scrollVerticalThresholdPx.toInt()
             drawingOffsetPointPxMutableLiveData.value = Point(offsetLeft, offsetTop)
         }
 
@@ -141,5 +144,6 @@ internal class MouseEventObserver(
 
     companion object {
         private const val SCROLL_SPEED_RATIO = 1 / 1.5F
+        private const val SCROLL_THRESHOLD_PIXEL = 1F
     }
 }


### PR DESCRIPTION
- Reduce the threshold of mouse wheel delta to 1 pixel to make scrolling smoother
- Set throttle to 5ms to reduce the number of redraw requests when the offset is updated.