### PR TITLE
Improve performance

### DIFF
--- a/libs/commons/src/main/kotlin/mono/common/WindowExt.kt
+++ b/libs/commons/src/main/kotlin/mono/common/WindowExt.kt
@@ -3,18 +3,30 @@ package mono.common
 import kotlinx.browser.window
 import org.w3c.dom.Window
 
-fun setTimeout(durationMillis: Int, action: () -> Unit): Timeout =
-    Timeout(window.setTimeout(action, durationMillis))
+fun setTimeout(durationMillis: Int, action: () -> Unit): Cancelable =
+    if (durationMillis == 0) {
+        AnimationFrame(window.requestAnimationFrame { action() })
+    } else {
+        Timeout(window.setTimeout(action, durationMillis))
+    }
 
-fun setInterval(durationMillis: Int, action: () -> Unit): Interval =
+fun setInterval(durationMillis: Int, action: () -> Unit): Cancelable =
     Interval(window.setInterval(action, durationMillis))
 
-class Timeout internal constructor(private val id: Int) {
-    fun cancel() = window.clearTimeout(id)
+interface Cancelable {
+    fun cancel()
 }
 
-class Interval internal constructor(private val id: Int) {
-    fun cancel() = window.clearInterval(id)
+private class Timeout(private val id: Int) : Cancelable {
+    override fun cancel() = window.clearTimeout(id)
+}
+
+private class Interval(private val id: Int) : Cancelable {
+    override fun cancel() = window.clearInterval(id)
+}
+
+private class AnimationFrame(private val id: Int) : Cancelable {
+    override fun cancel() = window.cancelAnimationFrame(id)
 }
 
 fun Window.isCommandKeySupported(): Boolean = navigator.platform.startsWith("Mac")

--- a/libs/htmlcanvas/src/main/kotlin/mono/html/canvas/CanvasViewController.kt
+++ b/libs/htmlcanvas/src/main/kotlin/mono/html/canvas/CanvasViewController.kt
@@ -59,7 +59,7 @@ class CanvasViewController(
         mousePointerLiveData = mouseEventController.mousePointerLiveData
         mouseEventController.drawingOffsetPointPxLiveData.observe(
             lifecycleOwner,
-            throttleDurationMillis = 5, // Reduce number of redraw request due to drawingInfo update
+            throttleDurationMillis = 0,
             listener = drawingInfoController::setOffset
         )
 

--- a/libs/htmlcanvas/src/main/kotlin/mono/html/canvas/canvas/BoardCanvasViewController.kt
+++ b/libs/htmlcanvas/src/main/kotlin/mono/html/canvas/canvas/BoardCanvasViewController.kt
@@ -18,6 +18,7 @@ internal class BoardCanvasViewController(
     }
 
     override fun drawInternal() {
+        context.font = drawingInfo.font
         for (row in drawingInfo.boardRowRange) {
             for (col in drawingInfo.boardColumnRange) {
                 drawPixel(board.get(col, row), row, col)
@@ -28,7 +29,6 @@ internal class BoardCanvasViewController(
     private fun drawPixel(pixel: Pixel, row: Int, column: Int) {
         if (!pixel.isTransparent) {
             context.fillStyle = pixel.highlight.paintColor
-            context.font = drawingInfo.font
             drawText(pixel.char.toString(), row, column)
         }
     }

--- a/libs/htmlcanvas/src/main/kotlin/mono/html/canvas/canvas/DrawingInfoController.kt
+++ b/libs/htmlcanvas/src/main/kotlin/mono/html/canvas/canvas/DrawingInfoController.kt
@@ -89,8 +89,8 @@ internal class DrawingInfoController(container: HTMLDivElement) {
         internal val boardColumnRange: IntRange =
             boardOffsetColumn..(boardOffsetColumn + columnCount)
 
-        fun toXPx(column: Double): Double = offsetPx.left + cellSizePx.width * column
-        fun toYPx(row: Double): Double = offsetPx.top + cellSizePx.height * row
+        fun toXPx(column: Double): Double = floor(offsetPx.left + cellSizePx.width * column)
+        fun toYPx(row: Double): Double = floor(offsetPx.top + cellSizePx.height * row)
         fun toBoardRow(yPx: Int): Int = floor((yPx - offsetPx.top) / cellSizePx.height).toInt()
         fun toBoardColumn(xPx: Int): Int = floor((xPx - offsetPx.left) / cellSizePx.width).toInt()
     }

--- a/libs/htmlcanvas/src/main/kotlin/mono/html/canvas/canvas/GridCanvasViewController.kt
+++ b/libs/htmlcanvas/src/main/kotlin/mono/html/canvas/canvas/GridCanvasViewController.kt
@@ -12,7 +12,7 @@ internal class GridCanvasViewController(
     lifecycleOwner: LifecycleOwner,
     canvas: HTMLCanvasElement,
     drawingInfoLiveData: LiveData<DrawingInfoController.DrawingInfo>
-) : BaseCanvasViewController(canvas) {
+) : BaseCanvasViewController(canvas, redrawWhenDrawingInfoUpdated = true) {
 
     init {
         drawingInfoLiveData.observe(lifecycleOwner, listener = ::setDrawingInfo)

--- a/libs/htmlcanvas/src/main/kotlin/mono/html/canvas/mouse/MouseEventObserver.kt
+++ b/libs/htmlcanvas/src/main/kotlin/mono/html/canvas/mouse/MouseEventObserver.kt
@@ -143,7 +143,7 @@ internal class MouseEventObserver(
     }
 
     companion object {
-        private const val SCROLL_SPEED_RATIO = 1 / 1.5F
+        private const val SCROLL_SPEED_RATIO = 1 / 1.3F
         private const val SCROLL_THRESHOLD_PIXEL = 1F
     }
 }

--- a/libs/livedata/src/main/kotlin/mono/livedata/LiveData.kt
+++ b/libs/livedata/src/main/kotlin/mono/livedata/LiveData.kt
@@ -17,6 +17,12 @@ abstract class LiveData<T>(initValue: T) {
     /**
      * Observes changes from live data within lifecycle with [lifecycleOwner].
      * Note that if [lifecycleOwner] is stopped, life data won't accept observer.
+     *
+     * @param throttleDurationMillis: Throttling configuration. By default, the throttle duration is
+     * set to -1 which means the observer will be executed immediately as the value is updated.
+     * With the throttle duration is 0, the execution will be run in the next frame. With throttle
+     * duration > 0, it will execute by timeout of the duration with the latest value bound to the
+     * live data.
      */
     fun observe(
         lifecycleOwner: LifecycleOwner,

--- a/libs/livedata/src/main/kotlin/mono/livedata/Observer.kt
+++ b/libs/livedata/src/main/kotlin/mono/livedata/Observer.kt
@@ -1,6 +1,6 @@
 package mono.livedata
 
-import mono.common.Timeout
+import mono.common.Cancelable
 import mono.common.setTimeout
 
 /**
@@ -32,7 +32,7 @@ internal class ThrottledObserver<T>(
     private val durationMillis: Int,
     private val observer: Observer<T>
 ) : Observer<T> {
-    private var currentTimeout: Timeout? = null
+    private var currentTimeout: Cancelable? = null
     private var currentValue: T? = null
 
     override fun onChanged(newValue: T) {

--- a/libs/statemanager/src/main/kotlin/mono/state/MainStateManager.kt
+++ b/libs/statemanager/src/main/kotlin/mono/state/MainStateManager.kt
@@ -77,7 +77,7 @@ class MainStateManager(
             .observe(lifecycleOwner, listener = ::updateMouseCursor)
 
         canvasManager.windowBoardBoundLiveData
-            .observe(lifecycleOwner, throttleDurationMillis = 10) {
+            .observe(lifecycleOwner, throttleDurationMillis = 0) {
                 windowBoardBound = it
                 console.warn(
                     "Drawing info: window board size $windowBoardBound • " +
@@ -97,7 +97,10 @@ class MainStateManager(
             listener = ::updateInteractionBounds
         )
 
-        redrawRequestMutableLiveData.observe(lifecycleOwner, 1) { redraw() }
+        redrawRequestMutableLiveData.observe(
+            lifecycleOwner,
+            throttleDurationMillis = 0
+        ) { redraw() }
 
         actionManager.retainableActionLiveData.observe(lifecycleOwner) {
             currentRetainableActionType = it


### PR DESCRIPTION
- Not update canvas information when scrolling
- Use `requestAnimationFramge` for running throttle live data observers with 0
- Use floor for x y value when drawing canvas
- Only update canvas's font once when drawing board canvas