### PR TITLE
Fix ID conflict when save and restore

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven { url = uri("https://dl.bintray.com/kotlin/kotlinx") }
 }
 
 dependencies {

--- a/app/src/main/kotlin/mono/app/MonoFlowApplication.kt
+++ b/app/src/main/kotlin/mono/app/MonoFlowApplication.kt
@@ -94,7 +94,7 @@ class MonoFlowApplication : LifecycleOwner() {
     }
 
     private fun backupShapes() {
-        localStorage[BACKUP_SHAPES_KEY] = shapeManager.toJson()
+        localStorage[BACKUP_SHAPES_KEY] = shapeManager.toJson(true)
     }
 
     private fun restoreShapes() {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,6 @@ allprojects {
 
 repositories {
     mavenCentral()
-    maven { url = uri("https://dl.bintray.com/kotlin/kotlinx") }
 }
 
 dependencies {

--- a/libs/commons/build.gradle.kts
+++ b/libs/commons/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven { url = uri("https://dl.bintray.com/kotlin/kotlinx") }
 }
 
 dependencies {

--- a/libs/export-shapes-modal/build.gradle.kts
+++ b/libs/export-shapes-modal/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven { url = uri("https://dl.bintray.com/kotlin/kotlinx") }
 }
 
 dependencies {
@@ -15,7 +14,7 @@ dependencies {
     implementation(project(":monoboard"))
     implementation(project(":shape"))
 
-    implementation("org.jetbrains.kotlinx:kotlinx-html:0.7.2")
+    implementation("org.jetbrains.kotlinx:kotlinx-html:0.7.3")
 
     implementation(kotlin("stdlib-js"))
     testImplementation(kotlin("test-js"))

--- a/libs/graphicsgeo/build.gradle.kts
+++ b/libs/graphicsgeo/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven { url = uri("https://dl.bintray.com/kotlin/kotlinx") }
 }
 
 dependencies {

--- a/libs/htmlcanvas/build.gradle.kts
+++ b/libs/htmlcanvas/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven { url = uri("https://dl.bintray.com/kotlin/kotlinx") }
 }
 
 dependencies {
@@ -15,7 +14,7 @@ dependencies {
     implementation(project(":monoboard"))
     implementation(project(":shape-interaction-bound"))
 
-    implementation("org.jetbrains.kotlinx:kotlinx-html:0.7.2")
+    implementation("org.jetbrains.kotlinx:kotlinx-html:0.7.3")
 
     testImplementation(kotlin("test-js"))
 }

--- a/libs/htmlmodal/build.gradle.kts
+++ b/libs/htmlmodal/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven { url = uri("https://dl.bintray.com/kotlin/kotlinx") }
 }
 
 dependencies {
@@ -12,7 +11,7 @@ dependencies {
     implementation(project(":lifecycle"))
     implementation(project(":livedata"))
 
-    implementation("org.jetbrains.kotlinx:kotlinx-html:0.7.2")
+    implementation("org.jetbrains.kotlinx:kotlinx-html:0.7.3")
 
     testImplementation(kotlin("test-js"))
 }

--- a/libs/htmltoolbar/build.gradle.kts
+++ b/libs/htmltoolbar/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven { url = uri("https://dl.bintray.com/kotlin/kotlinx") }
 }
 
 dependencies {
@@ -13,7 +12,7 @@ dependencies {
     implementation(project(":lifecycle"))
     implementation(project(":livedata"))
 
-    implementation("org.jetbrains.kotlinx:kotlinx-html:0.7.2")
+    implementation("org.jetbrains.kotlinx:kotlinx-html:0.7.3")
 
     testImplementation(kotlin("test-js"))
 }

--- a/libs/keycommand/build.gradle.kts
+++ b/libs/keycommand/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven { url = uri("https://dl.bintray.com/kotlin/kotlinx") }
 }
 
 dependencies {

--- a/libs/monobitmap/src/main/kotlin/mono/graphics/bitmap/MonoBitmapManager.kt
+++ b/libs/monobitmap/src/main/kotlin/mono/graphics/bitmap/MonoBitmapManager.kt
@@ -17,7 +17,7 @@ import mono.shape.shape.Text
  * Call [invalidate] to clean up cache of a shape.
  */
 class MonoBitmapManager {
-    private val idToBitmapMap: MutableMap<Int, VersionizedBitmap> = mutableMapOf()
+    private val idToBitmapMap: MutableMap<String, VersionizedBitmap> = mutableMapOf()
 
     fun getBitmap(shape: AbstractShape): MonoBitmap? {
         val cachedBitmap = getCacheBitmap(shape)

--- a/libs/shape-clipboard/build.gradle.kts
+++ b/libs/shape-clipboard/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven { url = uri("https://dl.bintray.com/kotlin/kotlinx") }
 }
 
 dependencies {
@@ -12,7 +11,7 @@ dependencies {
     implementation(project(":livedata"))
     implementation(project(":shape"))
 
-    implementation("org.jetbrains.kotlinx:kotlinx-html:0.7.2")
+    implementation("org.jetbrains.kotlinx:kotlinx-html:0.7.3")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.2.1")
 
     implementation(kotlin("stdlib-js"))

--- a/libs/shape-interaction-bound/src/main/kotlin/mono/shapebound/InteractionPoint.kt
+++ b/libs/shape-interaction-bound/src/main/kotlin/mono/shapebound/InteractionPoint.kt
@@ -10,7 +10,7 @@ import mono.shape.shape.Line
  * [left] and [top] are the center position of the interaction point, with board-related unit.
  */
 sealed class InteractionPoint(
-    val shapeId: Int,
+    val shapeId: String,
     val left: Double,
     val top: Double,
     val mouseCursor: String
@@ -20,7 +20,7 @@ sealed class InteractionPoint(
  * A sealed class for defining all possible scale interaction point types for a shape.
  */
 sealed class ScaleInteractionPoint(
-    shapeId: Int,
+    shapeId: String,
     left: Double,
     top: Double,
     mouseCursor: String
@@ -28,7 +28,7 @@ sealed class ScaleInteractionPoint(
     abstract fun createNewShapeBound(currentBound: Rect, newPoint: Point): Rect
 
     class TopLeft(
-        shapeId: Int,
+        shapeId: String,
         left: Double,
         top: Double
     ) : ScaleInteractionPoint(shapeId, left, top, "nwse-resize") {
@@ -37,7 +37,7 @@ sealed class ScaleInteractionPoint(
     }
 
     class TopMiddle(
-        shapeId: Int,
+        shapeId: String,
         left: Double,
         top: Double
     ) : ScaleInteractionPoint(shapeId, left, top, "ns-resize") {
@@ -46,7 +46,7 @@ sealed class ScaleInteractionPoint(
     }
 
     class TopRight(
-        shapeId: Int,
+        shapeId: String,
         left: Double,
         top: Double
     ) : ScaleInteractionPoint(shapeId, left, top, "nesw-resize") {
@@ -55,7 +55,7 @@ sealed class ScaleInteractionPoint(
     }
 
     class MiddleLeft(
-        shapeId: Int,
+        shapeId: String,
         left: Double,
         top: Double
     ) : ScaleInteractionPoint(shapeId, left, top, "ew-resize") {
@@ -64,7 +64,7 @@ sealed class ScaleInteractionPoint(
     }
 
     class MiddleRight(
-        shapeId: Int,
+        shapeId: String,
         left: Double,
         top: Double
     ) : ScaleInteractionPoint(shapeId, left, top, "ew-resize") {
@@ -73,7 +73,7 @@ sealed class ScaleInteractionPoint(
     }
 
     class BottomLeft(
-        shapeId: Int,
+        shapeId: String,
         left: Double,
         top: Double
     ) : ScaleInteractionPoint(shapeId, left, top, "nesw-resize") {
@@ -82,7 +82,7 @@ sealed class ScaleInteractionPoint(
     }
 
     class BottomMiddle(
-        shapeId: Int,
+        shapeId: String,
         left: Double,
         top: Double
     ) : ScaleInteractionPoint(shapeId, left, top, "ns-resize") {
@@ -91,7 +91,7 @@ sealed class ScaleInteractionPoint(
     }
 
     class BottomRight(
-        shapeId: Int,
+        shapeId: String,
         left: Double,
         top: Double
     ) : ScaleInteractionPoint(shapeId, left, top, "nwse-resize") {
@@ -104,21 +104,21 @@ sealed class ScaleInteractionPoint(
  * A sealed class to define all possible interaction points on Line shapes.
  */
 sealed class LineInteractionPoint(
-    shapeId: Int,
+    shapeId: String,
     left: Double,
     top: Double,
     mouseCursor: String
 ) : InteractionPoint(shapeId, left, top, mouseCursor) {
 
     class Anchor(
-        shapeId: Int,
+        shapeId: String,
         val anchor: Line.Anchor,
         left: Double,
         top: Double
     ) : LineInteractionPoint(shapeId, left, top, "move")
 
     class Edge(
-        shapeId: Int,
+        shapeId: String,
         val edgeId: Int,
         left: Double,
         top: Double,

--- a/libs/shape-interaction-bound/src/main/kotlin/mono/shapebound/LineInteractionBound.kt
+++ b/libs/shape-interaction-bound/src/main/kotlin/mono/shapebound/LineInteractionBound.kt
@@ -6,7 +6,7 @@ import mono.shape.shape.Line
  * A class which defines interaction bound for Line shapes.
  */
 class LineInteractionBound(
-    private val targetedShapeId: Int,
+    private val targetedShapeId: String,
     edges: List<Line.Edge>
 ) : InteractionBound() {
     private val reducedEdges: List<Line.Edge>

--- a/libs/shape-interaction-bound/src/main/kotlin/mono/shapebound/ScalableInteractionBound.kt
+++ b/libs/shape-interaction-bound/src/main/kotlin/mono/shapebound/ScalableInteractionBound.kt
@@ -6,7 +6,7 @@ import mono.graphics.geo.Rect
  * A class which defines interaction bound for scalable shapes.
  */
 class ScalableInteractionBound(
-    targetedShapeId: Int,
+    targetedShapeId: String,
     shapeBound: Rect
 ) : InteractionBound() {
     val left: Double = shapeBound.left.toDouble()

--- a/libs/shape/build.gradle.kts
+++ b/libs/shape/build.gradle.kts
@@ -10,6 +10,7 @@ repositories {
 dependencies {
     implementation(project(":graphicsgeo"))
     implementation(project(":livedata"))
+    implementation(project(":uuid"))
 
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.2.1")
 

--- a/libs/shape/src/main/kotlin/mono/shape/ShapeManager.kt
+++ b/libs/shape/src/main/kotlin/mono/shape/ShapeManager.kt
@@ -21,7 +21,7 @@ import mono.shape.shape.Group
 class ShapeManager {
     var root: Group = Group(parentId = null)
         private set
-    private var allShapeMap: MutableMap<Int, AbstractShape> = mutableMapOf(root.id to root)
+    private var allShapeMap: MutableMap<String, AbstractShape> = mutableMapOf(root.id to root)
 
     /**
      * Reflect the version of the root through live data. The other components are able to observe
@@ -48,14 +48,14 @@ class ShapeManager {
             if (currentVersion == newRoot.version) currentVersion - 1 else newRoot.version
     }
 
-    private fun createAllShapeMap(group: Group): MutableMap<Int, AbstractShape> {
-        val map: MutableMap<Int, AbstractShape> = mutableMapOf()
+    private fun createAllShapeMap(group: Group): MutableMap<String, AbstractShape> {
+        val map: MutableMap<String, AbstractShape> = mutableMapOf()
         map[group.id] = group
         createAllShapeMapRecursive(group, map)
         return map
     }
 
-    private fun createAllShapeMapRecursive(group: Group, map: MutableMap<Int, AbstractShape>) {
+    private fun createAllShapeMapRecursive(group: Group, map: MutableMap<String, AbstractShape>) {
         for (shape in group.items) {
             map[shape.id] = shape
             if (shape is Group) {
@@ -80,10 +80,10 @@ class ShapeManager {
         versionMutableLiveData.value = root.version
     }
 
-    internal fun getGroup(shapeId: Int?): Group? =
+    internal fun getGroup(shapeId: String?): Group? =
         if (shapeId == null) root else allShapeMap[shapeId] as? Group
 
-    fun getShape(shapeId: Int): AbstractShape? = allShapeMap[shapeId]
+    fun getShape(shapeId: String): AbstractShape? = allShapeMap[shapeId]
 
     internal fun register(shape: AbstractShape) {
         allShapeMap[shape.id] = shape
@@ -122,7 +122,7 @@ fun ShapeManager.toJson(): String = Json.encodeToString(root.toSerializableShape
 fun ShapeManager.replaceWithJson(jsonString: String): Boolean = try {
     val serializableGroup =
         Json.decodeFromString<AbstractSerializableShape>(jsonString) as SerializableGroup
-    val root = Group(serializableGroup, parentId = 0)
+    val root = Group(serializableGroup, parentId = null)
     replaceRoot(root)
     true
 } catch (e: Exception) {

--- a/libs/shape/src/main/kotlin/mono/shape/ShapeManager.kt
+++ b/libs/shape/src/main/kotlin/mono/shape/ShapeManager.kt
@@ -117,7 +117,8 @@ fun ShapeManager.group(sameParentShapes: List<AbstractShape>) =
 
 fun ShapeManager.ungroup(group: Group) = execute(Ungroup(group))
 
-fun ShapeManager.toJson(): String = Json.encodeToString(root.toSerializableShape())
+fun ShapeManager.toJson(isIdIncluded: Boolean): String =
+    Json.encodeToString(root.toSerializableShape(isIdIncluded))
 
 fun ShapeManager.replaceWithJson(jsonString: String): Boolean = try {
     val serializableGroup =

--- a/libs/shape/src/main/kotlin/mono/shape/list/QuickList.kt
+++ b/libs/shape/src/main/kotlin/mono/shape/list/QuickList.kt
@@ -8,7 +8,7 @@ package mono.shape.list
  */
 internal class QuickList<T : QuickList.Identifier> : Collection<T> {
     private val linkedList: DoubleLinkedList<T> = DoubleLinkedList()
-    private val map: MutableMap<Int, Node<T>> = mutableMapOf()
+    private val map: MutableMap<String, Node<T>> = mutableMapOf()
 
     override val size: Int
         get() = map.size
@@ -63,7 +63,7 @@ internal class QuickList<T : QuickList.Identifier> : Collection<T> {
         return result
     }
 
-    operator fun get(id: Int): T? = map[id]?.value
+    operator fun get(id: String): T? = map[id]?.value
 
     fun move(identifier: Identifier, moveActionType: MoveActionType): Boolean {
         if (size < 2) {
@@ -75,7 +75,7 @@ internal class QuickList<T : QuickList.Identifier> : Collection<T> {
     }
 
     interface Identifier {
-        val id: Int
+        val id: String
     }
 
     sealed class AddPosition {

--- a/libs/shape/src/main/kotlin/mono/shape/serialization/AbstractSerializableShape.kt
+++ b/libs/shape/src/main/kotlin/mono/shape/serialization/AbstractSerializableShape.kt
@@ -12,14 +12,14 @@ import mono.shape.shape.Text
 @Serializable
 sealed class AbstractSerializableShape {
     // null for not having id.
-    abstract val id: Int?
+    abstract val id: String?
 }
 
 @Serializable
 @SerialName("R")
 data class SerializableRectangle(
     @SerialName("i")
-    override val id: Int? = null,
+    override val id: String? = null,
     @SerialName("b")
     val bound: Rect,
     @SerialName("e")
@@ -30,7 +30,7 @@ data class SerializableRectangle(
 @SerialName("T")
 data class SerializableText(
     @SerialName("i")
-    override val id: Int? = null,
+    override val id: String? = null,
     @SerialName("b")
     val bound: Rect,
     @SerialName("t")
@@ -43,7 +43,7 @@ data class SerializableText(
 @SerialName("L")
 data class SerializableLine(
     @SerialName("i")
-    override val id: Int? = null,
+    override val id: String? = null,
     @SerialName("ps")
     val startPoint: DirectedPoint,
     @SerialName("pe")
@@ -62,7 +62,7 @@ data class SerializableLine(
 @SerialName("G")
 data class SerializableGroup(
     @SerialName("i")
-    override val id: Int? = null,
+    override val id: String? = null,
     @SerialName("ss")
     val shapes: List<AbstractSerializableShape>
 ) : AbstractSerializableShape()

--- a/libs/shape/src/main/kotlin/mono/shape/shape/AbstractShape.kt
+++ b/libs/shape/src/main/kotlin/mono/shape/shape/AbstractShape.kt
@@ -14,11 +14,15 @@ import mono.uuid.UUID
  *
  * Each shape's attributes might be changed and [version] reflects the update. To ensure the
  * [version]'s value is accurate, all properties modifying must be wrapped inside [update].
+ *
+ * @param id with null means the id will be automatically generated.
  */
 sealed class AbstractShape(
-    override val id: String = generateId(),
+    id: String?,
     internal var parentId: String? = null
 ) : QuickList.Identifier {
+    override val id: String = id ?: UUID.generate()
+
     var version: Int = 0
         private set
     abstract val bound: Rect
@@ -53,8 +57,4 @@ sealed class AbstractShape(
      * An interface which is used for updating extra value.
      */
     interface ExtraUpdater
-
-    companion object {
-        fun generateId(): String = UUID.generate()
-    }
 }

--- a/libs/shape/src/main/kotlin/mono/shape/shape/AbstractShape.kt
+++ b/libs/shape/src/main/kotlin/mono/shape/shape/AbstractShape.kt
@@ -32,7 +32,7 @@ sealed class AbstractShape(
      */
     open val extra: Any = Unit
 
-    abstract fun toSerializableShape(): AbstractSerializableShape
+    abstract fun toSerializableShape(isIdIncluded: Boolean): AbstractSerializableShape
 
     open fun setBound(newBound: Rect) = Unit
 

--- a/libs/shape/src/main/kotlin/mono/shape/shape/AbstractShape.kt
+++ b/libs/shape/src/main/kotlin/mono/shape/shape/AbstractShape.kt
@@ -4,6 +4,7 @@ import mono.graphics.geo.Point
 import mono.graphics.geo.Rect
 import mono.shape.list.QuickList
 import mono.shape.serialization.AbstractSerializableShape
+import mono.uuid.UUID
 
 /**
  * An abstract class which is used for defining all kinds of shape which are supported by the app.
@@ -15,8 +16,8 @@ import mono.shape.serialization.AbstractSerializableShape
  * [version]'s value is accurate, all properties modifying must be wrapped inside [update].
  */
 sealed class AbstractShape(
-    override val id: Int = generateId(),
-    internal var parentId: Int? = null
+    override val id: String = generateId(),
+    internal var parentId: String? = null
 ) : QuickList.Identifier {
     var version: Int = 0
         private set
@@ -54,12 +55,6 @@ sealed class AbstractShape(
     interface ExtraUpdater
 
     companion object {
-        private var NEXT_ID: Int = 1
-
-        fun generateId(): Int {
-            val id = NEXT_ID
-            NEXT_ID += 1
-            return id
-        }
+        fun generateId(): String = UUID.generate()
     }
 }

--- a/libs/shape/src/main/kotlin/mono/shape/shape/Group.kt
+++ b/libs/shape/src/main/kotlin/mono/shape/shape/Group.kt
@@ -43,8 +43,11 @@ class Group(
         }
     }
 
-    override fun toSerializableShape(): AbstractSerializableShape =
-        SerializableGroup(id, items.map { it.toSerializableShape() })
+    override fun toSerializableShape(isIdIncluded: Boolean): AbstractSerializableShape =
+        SerializableGroup(
+            id.takeIf { isIdIncluded },
+            items.map { it.toSerializableShape(isIdIncluded) }
+        )
 
     internal fun add(shape: AbstractShape, position: AddPosition = AddPosition.Last) = update {
         if (shape.parentId != null && shape.parentId != id) {

--- a/libs/shape/src/main/kotlin/mono/shape/shape/Group.kt
+++ b/libs/shape/src/main/kotlin/mono/shape/shape/Group.kt
@@ -14,7 +14,7 @@ import mono.shape.serialization.SerializableText
  * A special shape which manages a collection of shapes.
  */
 class Group(
-    id: String = generateId(),
+    id: String? = null,
     parentId: String?
 ) : AbstractShape(id = id, parentId = parentId) {
     private val quickList: QuickList<AbstractShape> = QuickList()
@@ -37,7 +37,7 @@ class Group(
     constructor(
         serializableGroup: SerializableGroup,
         parentId: String?
-    ) : this(id = serializableGroup.id ?: generateId(), parentId = parentId) {
+    ) : this(id = serializableGroup.id, parentId = parentId) {
         for (serializableShape in serializableGroup.shapes) {
             add(toShape(id, serializableShape))
         }

--- a/libs/shape/src/main/kotlin/mono/shape/shape/Group.kt
+++ b/libs/shape/src/main/kotlin/mono/shape/shape/Group.kt
@@ -13,7 +13,10 @@ import mono.shape.serialization.SerializableText
 /**
  * A special shape which manages a collection of shapes.
  */
-class Group(id: Int = generateId(), parentId: Int?) : AbstractShape(id = id, parentId = parentId) {
+class Group(
+    id: String = generateId(),
+    parentId: String?
+) : AbstractShape(id = id, parentId = parentId) {
     private val quickList: QuickList<AbstractShape> = QuickList()
     val items: Collection<AbstractShape> = quickList
     val itemCount: Int get() = items.size
@@ -33,7 +36,7 @@ class Group(id: Int = generateId(), parentId: Int?) : AbstractShape(id = id, par
 
     constructor(
         serializableGroup: SerializableGroup,
-        parentId: Int?
+        parentId: String?
     ) : this(id = serializableGroup.id ?: generateId(), parentId = parentId) {
         for (serializableShape in serializableGroup.shapes) {
             add(toShape(id, serializableShape))
@@ -65,7 +68,7 @@ class Group(id: Int = generateId(), parentId: Int?) : AbstractShape(id = id, par
     }
 
     companion object {
-        fun toShape(parentId: Int, serializableShape: AbstractSerializableShape): AbstractShape =
+        fun toShape(parentId: String, serializableShape: AbstractSerializableShape): AbstractShape =
             when (serializableShape) {
                 is SerializableRectangle -> Rectangle(serializableShape, parentId = parentId)
                 is SerializableText -> Text(serializableShape, parentId = parentId)

--- a/libs/shape/src/main/kotlin/mono/shape/shape/Line.kt
+++ b/libs/shape/src/main/kotlin/mono/shape/shape/Line.kt
@@ -74,8 +74,8 @@ import mono.shape.shape.line.LineHelper
 class Line(
     private var startPoint: DirectedPoint,
     private var endPoint: DirectedPoint,
-    id: Int = generateId(),
-    parentId: Int? = null
+    id: String = generateId(),
+    parentId: String? = null
 ) : AbstractShape(id = id, parentId = parentId) {
 
     private var jointPoints: List<Point> =
@@ -107,7 +107,7 @@ class Line(
             return Rect.byLTRB(left, top, right, bottom)
         }
 
-    internal constructor(serializableLine: SerializableLine, parentId: Int) : this(
+    internal constructor(serializableLine: SerializableLine, parentId: String) : this(
         serializableLine.startPoint,
         serializableLine.endPoint,
         id = serializableLine.id ?: generateId(),

--- a/libs/shape/src/main/kotlin/mono/shape/shape/Line.kt
+++ b/libs/shape/src/main/kotlin/mono/shape/shape/Line.kt
@@ -74,7 +74,7 @@ import mono.shape.shape.line.LineHelper
 class Line(
     private var startPoint: DirectedPoint,
     private var endPoint: DirectedPoint,
-    id: String = generateId(),
+    id: String? = null,
     parentId: String? = null
 ) : AbstractShape(id = id, parentId = parentId) {
 
@@ -110,7 +110,7 @@ class Line(
     internal constructor(serializableLine: SerializableLine, parentId: String) : this(
         serializableLine.startPoint,
         serializableLine.endPoint,
-        id = serializableLine.id ?: generateId(),
+        id = serializableLine.id,
         parentId = parentId
     ) {
         jointPoints = serializableLine.jointPoints

--- a/libs/shape/src/main/kotlin/mono/shape/shape/Line.kt
+++ b/libs/shape/src/main/kotlin/mono/shape/shape/Line.kt
@@ -123,9 +123,9 @@ class Line(
         anchorCharEnd = serializableLine.anchorCharEnd
     }
 
-    override fun toSerializableShape(): AbstractSerializableShape =
+    override fun toSerializableShape(isIdIncluded: Boolean): AbstractSerializableShape =
         SerializableLine(
-            id,
+            id.takeIf { isIdIncluded },
             startPoint,
             endPoint,
             jointPoints,

--- a/libs/shape/src/main/kotlin/mono/shape/shape/MockShape.kt
+++ b/libs/shape/src/main/kotlin/mono/shape/shape/MockShape.kt
@@ -8,7 +8,7 @@ import mono.shape.serialization.AbstractSerializableShape
  */
 class MockShape(
     rect: Rect,
-    parentId: Int? = null
+    parentId: String? = null
 ) : AbstractShape(parentId = parentId) {
 
     override fun toSerializableShape(): AbstractSerializableShape {

--- a/libs/shape/src/main/kotlin/mono/shape/shape/MockShape.kt
+++ b/libs/shape/src/main/kotlin/mono/shape/shape/MockShape.kt
@@ -9,7 +9,7 @@ import mono.shape.serialization.AbstractSerializableShape
 class MockShape(
     rect: Rect,
     parentId: String? = null
-) : AbstractShape(parentId = parentId) {
+) : AbstractShape(id = null, parentId = parentId) {
 
     override fun toSerializableShape(): AbstractSerializableShape {
         TODO("Not yet implemented")

--- a/libs/shape/src/main/kotlin/mono/shape/shape/MockShape.kt
+++ b/libs/shape/src/main/kotlin/mono/shape/shape/MockShape.kt
@@ -11,7 +11,7 @@ class MockShape(
     parentId: String? = null
 ) : AbstractShape(id = null, parentId = parentId) {
 
-    override fun toSerializableShape(): AbstractSerializableShape {
+    override fun toSerializableShape(isIdIncluded: Boolean): AbstractSerializableShape {
         TODO("Not yet implemented")
     }
 

--- a/libs/shape/src/main/kotlin/mono/shape/shape/Rectangle.kt
+++ b/libs/shape/src/main/kotlin/mono/shape/shape/Rectangle.kt
@@ -12,8 +12,8 @@ import mono.shape.serialization.SerializableRectangle
  */
 class Rectangle(
     rect: Rect,
-    id: Int = generateId(),
-    parentId: Int? = null
+    id: String = generateId(),
+    parentId: String? = null
 ) : AbstractShape(id, parentId = parentId) {
 
     override var bound: Rect = rect
@@ -33,8 +33,8 @@ class Rectangle(
     constructor(
         startPoint: Point,
         endPoint: Point,
-        id: Int = generateId(),
-        parentId: Int? = null
+        id: String = generateId(),
+        parentId: String? = null
     ) : this(
         Rect.byLTRB(startPoint.left, startPoint.top, endPoint.left, endPoint.top),
         id = id,
@@ -43,7 +43,7 @@ class Rectangle(
 
     internal constructor(
         serializableRectangle: SerializableRectangle,
-        parentId: Int? = null
+        parentId: String? = null
     ) : this(
         serializableRectangle.bound,
         id = serializableRectangle.id ?: generateId(),

--- a/libs/shape/src/main/kotlin/mono/shape/shape/Rectangle.kt
+++ b/libs/shape/src/main/kotlin/mono/shape/shape/Rectangle.kt
@@ -52,8 +52,8 @@ class Rectangle(
         extra = serializableRectangle.extra
     }
 
-    override fun toSerializableShape(): AbstractSerializableShape =
-        SerializableRectangle(id, bound, extra)
+    override fun toSerializableShape(isIdIncluded: Boolean): AbstractSerializableShape =
+        SerializableRectangle(id.takeIf { isIdIncluded }, bound, extra)
 
     override fun setBound(newBound: Rect) {
         bound = newBound

--- a/libs/shape/src/main/kotlin/mono/shape/shape/Rectangle.kt
+++ b/libs/shape/src/main/kotlin/mono/shape/shape/Rectangle.kt
@@ -12,7 +12,7 @@ import mono.shape.serialization.SerializableRectangle
  */
 class Rectangle(
     rect: Rect,
-    id: String = generateId(),
+    id: String? = null,
     parentId: String? = null
 ) : AbstractShape(id, parentId = parentId) {
 
@@ -33,7 +33,7 @@ class Rectangle(
     constructor(
         startPoint: Point,
         endPoint: Point,
-        id: String = generateId(),
+        id: String? = null,
         parentId: String? = null
     ) : this(
         Rect.byLTRB(startPoint.left, startPoint.top, endPoint.left, endPoint.top),
@@ -46,7 +46,7 @@ class Rectangle(
         parentId: String? = null
     ) : this(
         serializableRectangle.bound,
-        id = serializableRectangle.id ?: generateId(),
+        id = serializableRectangle.id,
         parentId = parentId
     ) {
         extra = serializableRectangle.extra

--- a/libs/shape/src/main/kotlin/mono/shape/shape/Text.kt
+++ b/libs/shape/src/main/kotlin/mono/shape/shape/Text.kt
@@ -61,8 +61,8 @@ class Text(
         updateRenderableText()
     }
 
-    override fun toSerializableShape(): AbstractSerializableShape =
-        SerializableText(id, bound, text, extra)
+    override fun toSerializableShape(isIdIncluded: Boolean): AbstractSerializableShape =
+        SerializableText(id.takeIf { isIdIncluded }, bound, text, extra)
 
     override fun setBound(newBound: Rect) = update {
         val isUpdated = bound != newBound

--- a/libs/shape/src/main/kotlin/mono/shape/shape/Text.kt
+++ b/libs/shape/src/main/kotlin/mono/shape/shape/Text.kt
@@ -16,7 +16,7 @@ import kotlin.math.max
  */
 class Text(
     rect: Rect,
-    id: String = generateId(),
+    id: String? = null,
     parentId: String? = null
 ) : AbstractShape(id = id, parentId = parentId) {
     private var userSettingSize: Size = Size.ZERO
@@ -39,7 +39,7 @@ class Text(
     constructor(
         startPoint: Point,
         endPoint: Point,
-        id: String = generateId(),
+        id: String? = null,
         parentId: String? = null
     ) : this(
         Rect.byLTRB(startPoint.left, startPoint.top, endPoint.left, endPoint.top),
@@ -49,7 +49,7 @@ class Text(
 
     internal constructor(serializableText: SerializableText, parentId: String?) : this(
         serializableText.bound,
-        id = serializableText.id ?: generateId(),
+        id = serializableText.id,
         parentId = parentId
     ) {
         extra = serializableText.extra

--- a/libs/shape/src/main/kotlin/mono/shape/shape/Text.kt
+++ b/libs/shape/src/main/kotlin/mono/shape/shape/Text.kt
@@ -16,8 +16,8 @@ import kotlin.math.max
  */
 class Text(
     rect: Rect,
-    id: Int = generateId(),
-    parentId: Int? = null
+    id: String = generateId(),
+    parentId: String? = null
 ) : AbstractShape(id = id, parentId = parentId) {
     private var userSettingSize: Size = Size.ZERO
         set(value) {
@@ -39,15 +39,15 @@ class Text(
     constructor(
         startPoint: Point,
         endPoint: Point,
-        id: Int = generateId(),
-        parentId: Int? = null
+        id: String = generateId(),
+        parentId: String? = null
     ) : this(
         Rect.byLTRB(startPoint.left, startPoint.top, endPoint.left, endPoint.top),
         id = id,
         parentId = parentId
     )
 
-    internal constructor(serializableText: SerializableText, parentId: Int?) : this(
+    internal constructor(serializableText: SerializableText, parentId: String?) : this(
         serializableText.bound,
         id = serializableText.id ?: generateId(),
         parentId = parentId

--- a/libs/shape/src/test/kotlin/mono/shape/ShapeManagerTest.kt
+++ b/libs/shape/src/test/kotlin/mono/shape/ShapeManagerTest.kt
@@ -33,7 +33,7 @@ class ShapeManagerTest {
         assertEquals(listOf(shape1, group1), target.root.items.toList())
         assertEquals(listOf(shape2), group1.items.toList())
 
-        val shape3 = MockShape(Rect.ZERO, parentId = 1000)
+        val shape3 = MockShape(Rect.ZERO, parentId = "1000")
         target.execute(AddShape(shape3))
         assertEquals(listOf(shape1, group1), target.root.items.toList())
         assertEquals(listOf(shape2), group1.items.toList())

--- a/libs/shape/src/test/kotlin/mono/shape/list/QuickListTest.kt
+++ b/libs/shape/src/test/kotlin/mono/shape/list/QuickListTest.kt
@@ -19,11 +19,11 @@ internal class QuickListTest {
         assertTrue(target.add(TestData.ITEM_1))
         assertFalse(target.add(TestData.ITEM_1))
         assertEquals(1, target.size)
-        assertEquals(TestData.ITEM_1, target[1])
+        assertEquals(TestData.ITEM_1, target["1"])
 
         target.add(TestData.ITEM_0, QuickList.AddPosition.First)
-        assertEquals(TestData.ITEM_0, target[0])
-        assertEquals(TestData.ITEM_1, target[1])
+        assertEquals(TestData.ITEM_0, target["0"])
+        assertEquals(TestData.ITEM_1, target["1"])
         assertEquals(listOf(TestData.ITEM_0, TestData.ITEM_1), target.toList())
 
         target.add(TestData.ITEM_3)
@@ -65,7 +65,7 @@ internal class QuickListTest {
         target.add(TestData.ITEM_3)
         target.addAll(
             listOf(TestData.ITEM_1, TestData.ITEM_2),
-            QuickList.AddPosition.After(Item(0))
+            QuickList.AddPosition.After(Item("0"))
         )
         assertEquals(
             listOf(TestData.ITEM_0, TestData.ITEM_1, TestData.ITEM_2, TestData.ITEM_3),
@@ -80,11 +80,11 @@ internal class QuickListTest {
 
         assertNull(target.remove(TestData.ITEM_2))
 
-        assertEquals(TestData.ITEM_1, target.remove(Item(1)))
+        assertEquals(TestData.ITEM_1, target.remove(Item("1")))
         assertEquals(1, target.size)
-        assertNull(target[1])
+        assertNull(target["1"])
 
-        assertEquals(TestData.ITEM_0, target.remove(Item(0)))
+        assertEquals(TestData.ITEM_0, target.remove(Item("0")))
         assertTrue(target.isEmpty())
     }
 
@@ -99,7 +99,7 @@ internal class QuickListTest {
     fun testMove_up() {
         target.addAll(TestData.ITEMS)
 
-        target.move(Item(1), QuickList.MoveActionType.UP)
+        target.move(Item("1"), QuickList.MoveActionType.UP)
         assertEquals(
             listOf(TestData.ITEM_0, TestData.ITEM_2, TestData.ITEM_1, TestData.ITEM_3),
             target.toList()
@@ -110,7 +110,7 @@ internal class QuickListTest {
     fun testMove_down() {
         target.addAll(TestData.ITEMS)
 
-        target.move(Item(2), QuickList.MoveActionType.DOWN)
+        target.move(Item("2"), QuickList.MoveActionType.DOWN)
         assertEquals(
             listOf(TestData.ITEM_0, TestData.ITEM_2, TestData.ITEM_1, TestData.ITEM_3),
             target.toList()
@@ -121,7 +121,7 @@ internal class QuickListTest {
     fun testMove_top() {
         target.addAll(TestData.ITEMS)
 
-        target.move(Item(1), QuickList.MoveActionType.TOP)
+        target.move(Item("1"), QuickList.MoveActionType.TOP)
         assertEquals(
             listOf(TestData.ITEM_0, TestData.ITEM_2, TestData.ITEM_3, TestData.ITEM_1),
             target.toList()
@@ -132,20 +132,20 @@ internal class QuickListTest {
     fun testMove_bottom() {
         target.addAll(TestData.ITEMS)
 
-        target.move(Item(2), QuickList.MoveActionType.BOTTOM)
+        target.move(Item("2"), QuickList.MoveActionType.BOTTOM)
         assertEquals(
             listOf(TestData.ITEM_2, TestData.ITEM_0, TestData.ITEM_1, TestData.ITEM_3),
             target.toList()
         )
     }
 
-    private data class Item(override val id: Int) : QuickList.Identifier
+    private data class Item(override val id: String) : QuickList.Identifier
 
     private object TestData {
-        val ITEM_0 = Item(0)
-        val ITEM_1 = Item(1)
-        val ITEM_2 = Item(2)
-        val ITEM_3 = Item(3)
+        val ITEM_0 = Item("0")
+        val ITEM_1 = Item("1")
+        val ITEM_2 = Item("2")
+        val ITEM_3 = Item("3")
 
         val ITEMS = listOf(ITEM_0, ITEM_1, ITEM_2, ITEM_3)
     }

--- a/libs/shape/src/test/kotlin/mono/shape/shape/GroupTest.kt
+++ b/libs/shape/src/test/kotlin/mono/shape/shape/GroupTest.kt
@@ -10,12 +10,12 @@ import kotlin.test.assertTrue
  * A test for [Group].
  */
 class GroupTest {
-    private val target: Group = Group(parentId = 100)
+    private val target: Group = Group(parentId = "100")
 
     @Test
     fun testAdd() {
         assertEquals(0, target.itemCount)
-        val invalidShape = Rectangle(Rect.ZERO, parentId = 10000)
+        val invalidShape = Rectangle(Rect.ZERO, parentId = "10000")
         val validShape1 = Rectangle(Rect.ZERO, parentId = null)
         val validShape2 = Rectangle(Rect.ZERO, parentId = target.id)
         val validShape3 = Rectangle(Rect.ZERO, parentId = null)

--- a/libs/shape/src/test/kotlin/mono/shape/shape/LineTest.kt
+++ b/libs/shape/src/test/kotlin/mono/shape/shape/LineTest.kt
@@ -131,6 +131,6 @@ class LineTest {
     }
 
     companion object {
-        private const val PARENT_ID = 1
+        private const val PARENT_ID = "1"
     }
 }

--- a/libs/shape/src/test/kotlin/mono/shape/shape/LineTest.kt
+++ b/libs/shape/src/test/kotlin/mono/shape/shape/LineTest.kt
@@ -19,7 +19,7 @@ class LineTest {
         val endPoint = DirectedPoint(DirectedPoint.Direction.HORIZONTAL, 3, 4)
         val line = Line(startPoint, endPoint, parentId = PARENT_ID)
 
-        val serializableLine = line.toSerializableShape() as SerializableLine
+        val serializableLine = line.toSerializableShape(true) as SerializableLine
         assertEquals(startPoint, serializableLine.startPoint)
         assertEquals(endPoint, serializableLine.endPoint)
         assertEquals(line.reducedJoinPoints, LineHelper.reduce(serializableLine.jointPoints))
@@ -45,7 +45,7 @@ class LineTest {
             isReduceRequired = true
         )
 
-        val serializableLine = line.toSerializableShape() as SerializableLine
+        val serializableLine = line.toSerializableShape(true) as SerializableLine
         assertEquals(newStartPoint, serializableLine.startPoint)
         assertEquals(newEndPoint, serializableLine.endPoint)
         assertEquals(line.reducedJoinPoints, LineHelper.reduce(serializableLine.jointPoints))
@@ -61,7 +61,7 @@ class LineTest {
         val line = Line(startPoint, endPoint, parentId = PARENT_ID)
         line.moveEdge(line.edges.first().id, Point(10, 10), isReduceRequired = true)
 
-        val serializableLine = line.toSerializableShape() as SerializableLine
+        val serializableLine = line.toSerializableShape(true) as SerializableLine
         assertEquals(startPoint, serializableLine.startPoint)
         assertEquals(endPoint, serializableLine.endPoint)
         assertEquals(line.reducedJoinPoints, LineHelper.reduce(serializableLine.jointPoints))
@@ -76,7 +76,7 @@ class LineTest {
         val endPoint = DirectedPoint(DirectedPoint.Direction.HORIZONTAL, 3, 4)
         val line = Line(startPoint, endPoint, parentId = PARENT_ID)
 
-        val serializableLine = line.toSerializableShape() as SerializableLine
+        val serializableLine = line.toSerializableShape(true) as SerializableLine
         val line2 = Line(serializableLine, parentId = PARENT_ID)
         assertEquals(line.getDirection(Line.Anchor.START), line2.getDirection(Line.Anchor.START))
         assertEquals(line.getDirection(Line.Anchor.END), line2.getDirection(Line.Anchor.END))
@@ -103,7 +103,7 @@ class LineTest {
             isReduceRequired = true
         )
 
-        val serializableLine = line.toSerializableShape() as SerializableLine
+        val serializableLine = line.toSerializableShape(true) as SerializableLine
         val line2 = Line(serializableLine, parentId = PARENT_ID)
         assertEquals(line.getDirection(Line.Anchor.START), line2.getDirection(Line.Anchor.START))
         assertEquals(line.getDirection(Line.Anchor.END), line2.getDirection(Line.Anchor.END))
@@ -120,7 +120,7 @@ class LineTest {
         val line = Line(startPoint, endPoint, parentId = PARENT_ID)
         line.moveEdge(line.edges.first().id, Point(10, 10), isReduceRequired = true)
 
-        val serializableLine = line.toSerializableShape() as SerializableLine
+        val serializableLine = line.toSerializableShape(true) as SerializableLine
         val line2 = Line(serializableLine, PARENT_ID)
         assertEquals(line.getDirection(Line.Anchor.START), line2.getDirection(Line.Anchor.START))
         assertEquals(line.getDirection(Line.Anchor.END), line2.getDirection(Line.Anchor.END))

--- a/libs/shape/src/test/kotlin/mono/shape/shape/RectangleTest.kt
+++ b/libs/shape/src/test/kotlin/mono/shape/shape/RectangleTest.kt
@@ -13,7 +13,7 @@ internal class RectangleTest {
     fun testSerialization_init() {
         val rectangle = Rectangle(Rect.byLTWH(1, 2, 3, 4), PARENT_ID)
 
-        val serializableRectangle = rectangle.toSerializableShape() as SerializableRectangle
+        val serializableRectangle = rectangle.toSerializableShape(true) as SerializableRectangle
         assertEquals(rectangle.bound, serializableRectangle.bound)
         assertEquals(rectangle.extra, serializableRectangle.extra)
     }
@@ -23,7 +23,7 @@ internal class RectangleTest {
         val rectangle = Rectangle(Rect.byLTWH(1, 2, 3, 4), parentId = PARENT_ID)
         rectangle.bound = Rect.byLTWH(5, 6, 7, 8)
 
-        val serializableRectangle = rectangle.toSerializableShape() as SerializableRectangle
+        val serializableRectangle = rectangle.toSerializableShape(true) as SerializableRectangle
         assertEquals(rectangle.bound, serializableRectangle.bound)
         assertEquals(rectangle.extra, serializableRectangle.extra)
     }
@@ -33,7 +33,7 @@ internal class RectangleTest {
         val rectangle = Rectangle(Rect.byLTWH(1, 2, 3, 4), parentId = PARENT_ID)
         rectangle.bound = Rect.byLTWH(5, 6, 7, 8)
 
-        val serializableRectangle = rectangle.toSerializableShape() as SerializableRectangle
+        val serializableRectangle = rectangle.toSerializableShape(true) as SerializableRectangle
 
         val rectangle2 = Rectangle(serializableRectangle, parentId = PARENT_ID)
         assertEquals(rectangle.bound, rectangle2.bound)

--- a/libs/shape/src/test/kotlin/mono/shape/shape/RectangleTest.kt
+++ b/libs/shape/src/test/kotlin/mono/shape/shape/RectangleTest.kt
@@ -42,6 +42,6 @@ internal class RectangleTest {
     }
 
     companion object {
-        private const val PARENT_ID = 1
+        private const val PARENT_ID = "1"
     }
 }

--- a/libs/shape/src/test/kotlin/mono/shape/shape/TextTest.kt
+++ b/libs/shape/src/test/kotlin/mono/shape/shape/TextTest.kt
@@ -72,6 +72,6 @@ class TextTest {
     }
 
     companion object {
-        private const val PARENT_ID = 1
+        private const val PARENT_ID = "1"
     }
 }

--- a/libs/shape/src/test/kotlin/mono/shape/shape/TextTest.kt
+++ b/libs/shape/src/test/kotlin/mono/shape/shape/TextTest.kt
@@ -13,7 +13,7 @@ class TextTest {
     fun testSerialization_init() {
         val text = Text(Rect.byLTWH(1, 2, 3, 4), parentId = PARENT_ID)
 
-        val serializableText = text.toSerializableShape() as SerializableText
+        val serializableText = text.toSerializableShape(true) as SerializableText
         assertEquals(text.text, serializableText.text)
         assertEquals(text.bound, serializableText.bound)
         assertEquals(text.extra, serializableText.extra)
@@ -24,7 +24,7 @@ class TextTest {
         val text = Text(Rect.byLTWH(1, 2, 3, 4), parentId = PARENT_ID)
         text.setBound(Rect.byLTWH(5, 6, 7, 8))
 
-        val serializableText = text.toSerializableShape() as SerializableText
+        val serializableText = text.toSerializableShape(true) as SerializableText
         assertEquals(text.text, serializableText.text)
         assertEquals(text.bound, serializableText.bound)
         assertEquals(text.extra, serializableText.extra)
@@ -35,7 +35,7 @@ class TextTest {
         val text = Text(Rect.byLTWH(1, 2, 3, 4), parentId = PARENT_ID)
         text.setText("Hello Hello!")
 
-        val serializableText = text.toSerializableShape() as SerializableText
+        val serializableText = text.toSerializableShape(true) as SerializableText
         assertEquals(text.text, serializableText.text)
         assertEquals(text.bound, serializableText.bound)
         assertEquals(text.extra, serializableText.extra)
@@ -47,7 +47,7 @@ class TextTest {
         text.setText("Hello Hello!")
         text.setBound(Rect.byLTWH(5, 5, 2, 2))
 
-        val serializableText = text.toSerializableShape() as SerializableText
+        val serializableText = text.toSerializableShape(true) as SerializableText
         val text2 = Text(serializableText, parentId = PARENT_ID)
         assertEquals(PARENT_ID, text2.parentId)
         assertEquals(text.text, text2.text)

--- a/libs/shapesearcher/src/main/kotlin/mono/shapesearcher/ShapeZoneAddressManager.kt
+++ b/libs/shapesearcher/src/main/kotlin/mono/shapesearcher/ShapeZoneAddressManager.kt
@@ -8,7 +8,7 @@ import mono.shape.shape.AbstractShape
  * This class also cache the addresses belong to the shape along with its version.
  */
 internal class ShapeZoneAddressManager(private val bitmapManager: MonoBitmapManager) {
-    private val idToZoneAddressMap: MutableMap<Int, VersionizedZoneAddresses> = mutableMapOf()
+    private val idToZoneAddressMap: MutableMap<String, VersionizedZoneAddresses> = mutableMapOf()
 
     fun getZoneAddresses(shape: AbstractShape): Set<ZoneAddress> {
         val cachedAddresses = getCachedAddresses(shape)

--- a/libs/shapesearcher/src/main/kotlin/mono/shapesearcher/ZoneOwnersManager.kt
+++ b/libs/shapesearcher/src/main/kotlin/mono/shapesearcher/ZoneOwnersManager.kt
@@ -9,7 +9,7 @@ import mono.graphics.geo.Rect
  * Owners of a zone will be stored in the same order as owners are added if overlapped.
  */
 internal class ZoneOwnersManager {
-    private val zoneToOwnersMap: MutableMap<ZoneAddress, MutableList<Int>> = mutableMapOf()
+    private val zoneToOwnersMap: MutableMap<ZoneAddress, MutableList<String>> = mutableMapOf()
 
     fun clear(clearBound: Rect) {
         val leftIndex = ZoneAddressFactory.toAddressIndex(clearBound.left)
@@ -25,21 +25,21 @@ internal class ZoneOwnersManager {
         }
     }
 
-    fun registerOwnerAddresses(ownerId: Int, addresses: Set<ZoneAddress>) {
+    fun registerOwnerAddresses(ownerId: String, addresses: Set<ZoneAddress>) {
         for (address in addresses) {
             zoneToOwnersMap.getOrPut(address) { mutableListOf() }.add(ownerId)
         }
     }
 
-    fun getPotentialOwners(point: Point): List<Int> {
+    fun getPotentialOwners(point: Point): List<String> {
         val address = ZoneAddressFactory.toAddress(point.row, point.column)
         return zoneToOwnersMap[address].orEmpty()
     }
 
-    fun getAllPotentialOwnersInZone(zone: Rect): Set<Int> {
+    fun getAllPotentialOwnersInZone(zone: Rect): Set<String> {
         val address1 = ZoneAddressFactory.toAddress(zone.top, zone.left)
         val address2 = ZoneAddressFactory.toAddress(zone.bottom, zone.right)
-        val owners = mutableSetOf<Int>()
+        val owners = mutableSetOf<String>()
         for (addressRow in address1.row..address2.row) {
             for (addressCol in address1.column..address2.column) {
                 val address = ZoneAddressFactory.get(addressRow, addressCol)

--- a/libs/statemanager/build.gradle.kts
+++ b/libs/statemanager/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven { url = uri("https://dl.bintray.com/kotlin/kotlinx") }
 }
 
 dependencies {
@@ -25,7 +24,7 @@ dependencies {
     implementation(project(":shape-interaction-bound"))
     implementation(project(":shapesearcher"))
 
-    implementation("org.jetbrains.kotlinx:kotlinx-html:0.7.2")
+    implementation("org.jetbrains.kotlinx:kotlinx-html:0.7.3")
 
     testImplementation(kotlin("test-js"))
 }

--- a/libs/statemanager/src/main/kotlin/mono/state/ClipboardManager.kt
+++ b/libs/statemanager/src/main/kotlin/mono/state/ClipboardManager.kt
@@ -31,7 +31,7 @@ internal class ClipboardManager(
     }
 
     fun copySelectedShapes() {
-        val serializableShapes = selectedShapes.map { it.toSerializableShape() }
+        val serializableShapes = selectedShapes.map { it.toSerializableShape(false) }
         shapeClipboardManager.setClipboard(serializableShapes)
     }
 
@@ -59,7 +59,7 @@ internal class ClipboardManager(
             return
         }
         val currentSelectedShapes = selectedShapes
-        val serializableShapes = currentSelectedShapes.map { it.toSerializableShape() }
+        val serializableShapes = currentSelectedShapes.map { it.toSerializableShape(false) }
         val minLeft = currentSelectedShapes.minOf { it.bound.left }
         val minTop = currentSelectedShapes.minOf { it.bound.top }
 

--- a/libs/statemanager/src/main/kotlin/mono/state/MainStateManager.kt
+++ b/libs/statemanager/src/main/kotlin/mono/state/MainStateManager.kt
@@ -112,7 +112,7 @@ class MainStateManager(
                 OneTimeActionType.IDLE -> Unit
 
                 OneTimeActionType.SAVE_SHAPES_AS ->
-                    fileMediator.saveFile(shapeManager.toJson())
+                    fileMediator.saveFile(shapeManager.toJson(true))
                 OneTimeActionType.OPEN_SHAPES ->
                     openSavedFile()
                 OneTimeActionType.EXPORT_SELECTED_SHAPES ->

--- a/libs/statemanager/src/main/kotlin/mono/state/command/mouse/AddShapeMouseCommand.kt
+++ b/libs/statemanager/src/main/kotlin/mono/state/command/mouse/AddShapeMouseCommand.kt
@@ -64,10 +64,10 @@ internal class AddShapeMouseCommand(private val shapeFactory: ShapeFactory) : Mo
 }
 
 internal sealed class ShapeFactory {
-    abstract fun createShape(position: Point, parentId: Int): AbstractShape
+    abstract fun createShape(position: Point, parentId: String): AbstractShape
 
     object RectangleFactory : ShapeFactory() {
-        override fun createShape(position: Point, parentId: Int): AbstractShape =
+        override fun createShape(position: Point, parentId: String): AbstractShape =
             Rectangle(position, position, parentId = parentId)
     }
 }

--- a/libs/uuid/build.gradle.kts
+++ b/libs/uuid/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven { url = uri("https://dl.bintray.com/kotlin/kotlinx") }
 }
 
 dependencies {

--- a/libs/uuid/build.gradle.kts
+++ b/libs/uuid/build.gradle.kts
@@ -1,0 +1,28 @@
+plugins {
+    kotlin("js")
+}
+
+repositories {
+    mavenCentral()
+    maven { url = uri("https://dl.bintray.com/kotlin/kotlinx") }
+}
+
+dependencies {
+    implementation(kotlin("stdlib-js"))
+    testImplementation(kotlin("test-js"))
+}
+
+val compilerType: org.jetbrains.kotlin.gradle.plugin.KotlinJsCompilerType by ext
+kotlin {
+    js(compilerType) {
+        browser {
+            testTask {
+                useKarma {
+                    useChromeHeadless()
+                    webpackConfig.cssSupport.enabled = true
+                }
+            }
+        }
+        binaries.executable()
+    }
+}

--- a/libs/uuid/src/main/kotlin/mono/uuid/UUID.kt
+++ b/libs/uuid/src/main/kotlin/mono/uuid/UUID.kt
@@ -1,0 +1,41 @@
+package mono.uuid
+
+import kotlin.js.Date
+import kotlin.random.Random
+
+/**
+ * An object class that generate unique ID.
+ *
+ * Version 1:
+ * ```
+ * Structure: version datetime random random
+ * Length   :   3        8      10     10
+ * ```
+ * Version: 01-
+ * Datetime: Base64-like encoded current time (8 chars)
+ * Random: Base64-like encoded random number (10 chars)
+ */
+object UUID {
+    const val VERSION = 1
+
+    private val BASE64_CHARS =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+=".toCharArray()
+
+    fun generate(): String {
+        val part1 = Date().getTime().toBits().toBase64().dropLast(3)
+        val part2 = Random.nextLong().toBase64()
+        val part3 = Random.nextLong().toBase64()
+        return "0$VERSION-$part1$part2$part3"
+    }
+
+    private fun Long.toBase64(): String {
+        var number = this
+        val chars = CharArray(10)
+        for (i in chars.indices) {
+            val v = number and 0b0111111
+            number = number ushr 6
+            chars[i] = BASE64_CHARS[v.toInt()]
+        }
+        return chars.joinToString("")
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,7 +17,8 @@ val moduleMap = mapOf(
     "shape-clipboard" to "libs/shape-clipboard",
     "shape-interaction-bound" to "libs/shape-interaction-bound",
     "shapesearcher" to "libs/shapesearcher",
-    "statemanager" to "libs/statemanager"
+    "statemanager" to "libs/statemanager",
+    "uuid" to "libs/uuid"
 )
 
 moduleMap.entries.forEach { (name, path) ->


### PR DESCRIPTION
This is a fix to #138 because storing and restoring ID cause conflicts between old and new ids which is generated from 0

- Convert ID and parentID to String
- Create UUID generator based on date time and random two numbers
- Hide id generator from outside of the abstract shape

For fixing CI, this PR also including `bintrays` removal and update `kotlinx-html:0.7.3`